### PR TITLE
Added support for handling JDAY to read_MESH_OutputTimeseries_csv

### DIFF
--- a/R/read_MESH_OutputTimeseries_csv.R
+++ b/R/read_MESH_OutputTimeseries_csv.R
@@ -40,7 +40,7 @@ read_MESH_OutputTimeseries_csv <- function(outputFile, timezone = "", missingVal
   names(output) <- vars
   
   # make sure it's actually a time series
-  if ( vars[1] != "YEAR" | vars[2] != "DAY") {
+  if ( vars[1] != "YEAR" | !(vars[2] == "DAY" | vars[2] == "JDAY")) {
     cat('Error: not a time series file\n')
     return(FALSE)
   }
@@ -57,7 +57,11 @@ read_MESH_OutputTimeseries_csv <- function(outputFile, timezone = "", missingVal
   }
   
   if (!subdaily) {
-    DATE <- paste(output$YEAR, "-", output$DAY, sep = "")
+    if (vars[2] == "DAY") {
+      DATE <- paste(output$YEAR, "-", output$DAY, sep = "")
+    } else if (vars[2] == "JDAY") {
+      DATE <- paste(output$YEAR, "-", output$JDAY, sep = "")
+    }
     DATE <- as.Date(DATE, format = "%Y-%j")
     returned_df <- data.frame(DATE, output[, -(1:2)])
      # set missing values to NA


### PR DESCRIPTION
JDAY replaces DAY in csv outputs from versions of MESH past 1.4.1723, documented at https://wiki.usask.ca/display/MESH/Variable+Name+Updates. This update adds JDAY handling to the read_MESH_OutputTimeseries_csv code.